### PR TITLE
Fix dataContainerIDs's search in nicovide.js

### DIFF
--- a/lib/nicovideo.js
+++ b/lib/nicovideo.js
@@ -31,9 +31,18 @@ class Nicovideo extends EventEmitter {
 
 					const data = dataContainerIDs
 						.reduce((result, id) => {
-							result[id] = JSON.parse(document.querySelector(`#${id}DataContainer`).innerHTML);
-							return result;
+							const dom = document.querySelector(`#${id}DataContainer`);
+
+							if (dom) {
+								result[id] = JSON.parse(dom.innerHTML);
+								return result;
+							}
+							return null;
 						}, {});
+
+					if (data === null) {
+						return reject(new Error('Error: login failed'));
+					}
 
 					data.watchAPI.flashvars.flvInfo = querystring
 						.unescape(data.watchAPI.flashvars.flvInfo)

--- a/test/nicovideo.spec.js
+++ b/test/nicovideo.spec.js
@@ -46,3 +46,12 @@ test('download videos', () => {
 			console.log(err);
 		});
 });
+
+test('should fail when can not logIn', t => {
+	return niconico
+		.login('', '')
+		.then(() => new Nicovideo().watch(VIDEO_ID))
+		.then(() => t.fail())
+		.catch(() => t.pass());
+});
+


### PR DESCRIPTION
hello :)

We fixed the bug.
document.querySelector(`#${id}DataContainer`) is null when are not logged in.

cheers.